### PR TITLE
ArmPkg/ArmPsciMpServices Add EFI_NOT_READY return

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -103,7 +103,9 @@ DispatchCpu (
 
   ArmCallSmc (&Args);
 
-  if (Args.Arg0 != ARM_SMC_PSCI_RET_SUCCESS) {
+  if (Args.Arg0 == ARM_SMC_PSCI_RET_ALREADY_ON) {
+    Status = EFI_NOT_READY;
+  } else if (Args.Arg0 != ARM_SMC_PSCI_RET_SUCCESS) {
     DEBUG ((DEBUG_ERROR, "PSCI_CPU_ON call failed: %d\n", Args.Arg0));
     Status = EFI_DEVICE_ERROR;
   }


### PR DESCRIPTION
Add EFI_NOT_READY return if the CPU can not be enabled if the processor is already on.

This can occur in normal use if the CPU is still being turned off from a previous call when this is called again.


Change-Id: I8f677edca8b384f06239a74b1c7636a4a02e2597

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
